### PR TITLE
Название таска будет только в начале строки

### DIFF
--- a/report.py
+++ b/report.py
@@ -113,7 +113,7 @@ if __name__ == '__main__':
     with open(csv_file_name, encoding='utf-8') as fp:
         file = csv.DictReader(fp)
         for row in file:
-            task_raw = re.search('[A-Z]+-[0-9]+', row['Description'])
+            task_raw = re.search('^[A-Z]+-[0-9]+', row['Description'])
             task = JIRA_COM_TASK if task_raw is None else task_raw.group(0)
             worklog = Worklog(
                 datetime.datetime.strptime(


### PR DESCRIPTION
Теперь ожидаем название таска только в начале строки, потому что иначе время из записи с описанием 'Общался с Юлей по ее задаче MOB-6969'  будет залогировано в задачу MOB-6969 вместо того, чтобы уйти в личную COM задачу.

Note: Пока не проверял, но должно работать как ожидается.